### PR TITLE
Terr perf

### DIFF
--- a/common/graph/getGraphExpressions.js
+++ b/common/graph/getGraphExpressions.js
@@ -2,37 +2,36 @@
 
 var StringMap = require('stringmap');
 
+var Expressions = require('../../database').Expressions;
+
 /*
     graph is an abstract page graph
     The returned value is a dictionary object key'ed on expression_id
 */
 // an indirection to avoid a circular dependency with database/index.js
-module.exports = function(Expressions){
-    
-    return function(graph){
-        console.time('getGraphExpressions');
-        
-        var expressionsById = Object.create(null);
-        var ids = new Set();
+module.exports = function(graph){
+    console.time('getGraphExpressions');
 
-        var expressionIdToURL = new StringMap();
-        
-        graph.nodes.forEach(function(node){
-            var id = node.expression_id;
-            if(id !== null){
-                ids.add(id);
-                expressionIdToURL.set(String(id), node.url);
-            }
+    var expressionsById = Object.create(null);
+    var ids = new Set();
+
+    var expressionIdToURL = new StringMap();
+
+    graph.nodes.forEach(function(node){
+        var id = node.expression_id;
+        if(id !== null){
+            ids.add(id);
+            expressionIdToURL.set(String(id), node.url);
+        }
+    });
+
+    return ids.size > 0 ? Expressions.getExpressionsWithContent(ids).then(function(expressions){
+        expressions.forEach(function(expr){
+            expr.url = expressionIdToURL.get(String(expr.id));
+            expressionsById[expr.id] = expr;
         });
 
-        return ids.size > 0 ? Expressions.getExpressionsWithContent(ids).then(function(expressions){
-            expressions.forEach(function(expr){
-                expr.url = expressionIdToURL.get(String(expr.id));
-                expressionsById[expr.id] = expr;
-            });
-
-            console.timeEnd('getGraphExpressions');
-            return expressionsById;
-        }) : expressionsById;
-    };
+        console.timeEnd('getGraphExpressions');
+        return expressionsById;
+    }) : expressionsById;
 };

--- a/common/graph/getGraphExpressions.js
+++ b/common/graph/getGraphExpressions.js
@@ -10,6 +10,8 @@ var StringMap = require('stringmap');
 module.exports = function(Expressions){
     
     return function(graph){
+        console.time('getGraphExpressions');
+        
         var expressionsById = Object.create(null);
         var ids = new Set();
 
@@ -29,6 +31,7 @@ module.exports = function(Expressions){
                 expressionsById[expr.id] = expr;
             });
 
+            console.timeEnd('getGraphExpressions');
             return expressionsById;
         }) : expressionsById;
     };

--- a/database/getTerritoireScreenData.js
+++ b/database/getTerritoireScreenData.js
@@ -1,0 +1,70 @@
+"use strict";
+
+var database = require('../database/index.js');
+
+var getGraphExpressions = require('../common/graph/getGraphExpressions');
+
+var getTerritoireResourceGraph = require('../server/getTerritoireResourceGraph');
+var simplifyExpression = require('../server/simplifyExpression');
+
+
+
+module.exports = function getTerritoireScreenData(territoireId){
+    console.log('getTerritoireScreenData', territoireId);
+
+    var territoireP = database.Territoires.findById(territoireId);
+    var relevantQueriesP = database.Queries.findByBelongsTo(territoireId);
+
+    var queryReadyP = relevantQueriesP.then(function(queries){
+        return Promise.all(queries.map(function(q){
+            return database.QueryResults.findLatestByQueryId(q.id).then(function(queryResults){
+                q.oracleResults = queryResults && queryResults.results;
+            });
+        }));
+    });
+
+    var abstractPageGraphP = getTerritoireResourceGraph(territoireId)
+        .then(function(res){
+            return res.graph;
+        });
+
+    var expressionByIdP = abstractPageGraphP
+        .then(getGraphExpressions)
+        .then(function(expressionById){
+            console.time('simplifyExpression');
+            Object.keys(expressionById).forEach(function(id){
+                expressionById[id] = simplifyExpression(expressionById[id]);
+            });
+            console.timeEnd('simplifyExpression');
+            return expressionById;
+        });
+
+    var annotationByResourceIdP = abstractPageGraphP
+        .then(function(graph){
+            console.time('fetching annotations');
+            return database.complexQueries.getGraphAnnotations(graph, territoireId);
+        });
+    annotationByResourceIdP.then(console.timeEnd.bind(console, 'fetching annotations'))
+
+    // timing of this query will make the values certainly out-of-sync with when 
+    var progressIndicatorsP = database.complexQueries.getProgressIndicators(territoireId);
+
+    console.time('getProgressIndicators');
+    progressIndicatorsP.then(console.timeEnd.bind(console, 'getProgressIndicators'))
+
+    console.time('all data');
+    return Promise.all([
+        territoireP, relevantQueriesP, abstractPageGraphP, progressIndicatorsP, expressionByIdP, annotationByResourceIdP, queryReadyP
+    ]).then(function(res){
+        console.timeEnd('all data');
+        var territoire = res[0];
+
+        territoire.queries = res[1];
+        territoire.graph = res[2];
+        territoire.progressIndicators = res[3];
+        territoire.expressionById = res[4];
+        territoire.annotationByResourceId = res[5];
+
+        return territoire;
+    });
+};

--- a/database/getTerritoireScreenData.js
+++ b/database/getTerritoireScreenData.js
@@ -23,10 +23,12 @@ module.exports = function getTerritoireScreenData(territoireId){
         }));
     });
 
+    console.time('getTerritoireResourceGraph')
     var abstractPageGraphP = getTerritoireResourceGraph(territoireId)
         .then(function(res){
             return res.graph;
         });
+    abstractPageGraphP.then(console.timeEnd.bind(console, 'getTerritoireResourceGraph'))
 
     var expressionByIdP = abstractPageGraphP
         .then(getGraphExpressions)

--- a/database/index.js
+++ b/database/index.js
@@ -131,7 +131,7 @@ module.exports = {
             Edges are {source: Node, target: Node}
         */
         getGraphFromRootURIs: function(rootURIs){
-            console.time('getGraphFromRootURIs');
+            //console.time('getGraphFromRootURIs');
             //var PERIPHERIC_DEPTH = 10000;
             
             //console.log('getGraphFromRootURIs', rootURIs.toJSON());
@@ -143,12 +143,12 @@ module.exports = {
             var aliasToCanonicalResourceId = new StringMap/*<ResourceIdStr, ResourceIdStr>*/();
 
             function buildGraph(resourceIds, depth){
-                console.time('buildGraph '+resourceIds.size);
+                //console.time('buildGraph '+resourceIds.size);
                 
-                var k = 'findValidByIds '+resourceIds.size;
-                console.time(k);
+                //var k = 'findValidByIds '+resourceIds.size;
+                //console.time(k);
                 return Resources.findValidByIds(resourceIds).then(function(resources){
-                    console.timeEnd(k);
+                    //console.timeEnd(k);
                     
                     // create nodes for non-alias
                     resources.forEach(function(res){
@@ -181,12 +181,12 @@ module.exports = {
                         buildGraph(aliasTargetIds, depth) : // same depth on purpose
                         Promise.resolve();
                     
-                    console.time('Links.findBySources '+resourceIds.size);
+                    //console.time('Links.findBySources '+resourceIds.size);
                     var nextDepthGraphP = Links.findBySources(new Set(resourcesWithExpression.map(function(r){
                         return r.id;
                     })))
                         .then(function(links){
-                            console.timeEnd('Links.findBySources '+resourceIds.size);
+                            //console.timeEnd('Links.findBySources '+resourceIds.size);
                             var nextResourceIds = new Set();
 
                             links.forEach(function(l){
@@ -206,7 +206,7 @@ module.exports = {
                         });
                     
                     var resP = Promise.all([aliasRetryBuildGraphP, nextDepthGraphP])
-                    resP.then(console.timeEnd.bind(console, 'buildGraph '+resourceIds.size));
+                    //resP.then(console.timeEnd.bind(console, 'buildGraph '+resourceIds.size));
                     
                     return resP;
                 });
@@ -222,7 +222,7 @@ module.exports = {
                         e.source = Number(e.source);
                     });
 
-                    console.timeEnd('getGraphFromRootURIs');
+                    //console.timeEnd('getGraphFromRootURIs');
                     return {
                         nodes: nodes,
                         edges: edges,

--- a/postgresDB/Resources.js
+++ b/postgresDB/Resources.js
@@ -136,8 +136,7 @@ module.exports = {
     findValidByURLs: function(urls){
         return databaseP.then(function(db){
             var query = resources
-                .select('*')
-                .from(resources)
+                .select(resources.star())
                 .where(
                     resources.url.in(urls.toJSON()).and(
                         isValidResourceExpression
@@ -161,8 +160,7 @@ module.exports = {
     findValidByIds: function(ids){
         return databaseP.then(function(db){
             var query = resources
-                .select('*')
-                .from(resources)
+                .select(resources.star())
                 .where(
                     resources.id.in(ids.toJSON()).and(
                         isValidResourceExpression

--- a/server/getTerritoireResourceGraph.js
+++ b/server/getTerritoireResourceGraph.js
@@ -1,0 +1,55 @@
+"use strict";
+
+var fork = require('child_process').fork;
+
+var StringMap = require('stringmap');
+
+var w = fork(require.resolve('./territoireGraphCache-worker'))
+
+var terrIdToPromiseResolve = new Map();
+
+w.on('message', function(res){
+    var id = res.territoireId;
+    
+    var receivedNodes = res.graph.nodes;
+    var nodes = new StringMap();
+    
+    receivedNodes.forEach(function(n){
+        nodes.set(String(n.id), n);
+    })
+    
+    res.graph.nodes = nodes;
+    res.graph.toJSON = function(){
+        return {
+            nodes: res.graph.nodes.values(),
+            edges: res.graph.edges
+        }
+    }
+    
+    terrIdToPromiseResolve.get(id).resolve(res);
+    terrIdToPromiseResolve.delete(id);
+})
+
+
+module.exports = function getTerritoireResourceGraph(territoireId){
+    //console.log('getTerritoireResourceGraph', territoireId, terrIdToPromiseResolve.has(territoireId));
+    
+    if(terrIdToPromiseResolve.has(territoireId))
+        return terrIdToPromiseResolve.get(territoireId).promise;
+    else{
+        var resolve;
+        var p = new Promise(function(_resolve){ resolve = _resolve; });
+        
+        terrIdToPromiseResolve.set(territoireId, {
+            promise: p,
+            resolve: resolve
+        });
+        
+        w.send({
+            territoireId: territoireId
+        });
+        
+        return p;
+    } 
+    
+};

--- a/server/index.js
+++ b/server/index.js
@@ -25,7 +25,9 @@ var database = require('../database');
 //var dropAllTables = require('../postgresDB/dropAllTables');
 //var createTables = require('../postgresDB/createTables');
 var onQueryCreated = require('./onQueryCreated');
-var getGraphExpressions = require('../common/graph/getGraphExpressions')(database.Expressions);
+var getGraphExpressions = require('../common/graph/getGraphExpressions');
+var getTerritoireScreenData = require('../database/getTerritoireScreenData');
+
 
 var TerritoireListScreen = React.createFactory(require('../client/components/TerritoireListScreen'));
 var OraclesScreen = React.createFactory(require('../client/components/OraclesScreen'));
@@ -208,7 +210,7 @@ app.get('/territoire/:id', function(req, res){
     }
     else{
         var userInitDataP = database.complexQueries.getUserInitData(user.id);
-        var territoireScreenDataP = database.complexQueries.getTerritoireScreenData(territoireId);
+        var territoireScreenDataP = getTerritoireScreenData(territoireId);
 
         // Create a fresh document every time
         Promise.all([makeDocument(indexHTMLStr), userInitDataP, territoireScreenDataP])
@@ -545,10 +547,11 @@ app.get('/territoire-view-data/:id', function(req, res){
     
     var territoireId = Number(req.params.id);
     
-    database.complexQueries.getTerritoireScreenData(territoireId).then(function(territoireData){
+    getTerritoireScreenData(territoireId).then(function(territoireData){
         res.status(200).send(territoireData);
     }).catch(function(err){
-        res.status(500).send('database problem '+ err);
+        console.error('database problem', err, err.stack);
+        res.status(500).send('database problem '+err);
     });
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 require('../ES-mess');
-require('better-log').install();
+//require('better-log').install();
 process.title = "MyWI server";
 
 var resolve = require('path').resolve;

--- a/server/index.js
+++ b/server/index.js
@@ -210,19 +210,25 @@ app.get('/territoire/:id', function(req, res){
     }
     else{
         var userInitDataP = database.complexQueries.getUserInitData(user.id);
-        var territoireScreenDataP = getTerritoireScreenData(territoireId);
+        var territoireP = database.Territoires.findById(territoireId);
 
         // Create a fresh document every time
-        Promise.all([makeDocument(indexHTMLStr), userInitDataP, territoireScreenDataP])
+        Promise.all([makeDocument(indexHTMLStr), userInitDataP, territoireP])
             .then(function(result){
                 var doc = result[0].document;
                 var dispose = result[0].dispose;
 
                 var initData = result[1];
-                var territoireScreenData = result[2];
+                var territoire = result[2];
 
                 renderDocumentWithData(doc, Object.assign(initData, {
-                    territoire: territoireScreenData
+                    territoire: Object.assign({
+                        queries: [],
+                        graph: {
+                            nodes: [],
+                            edges: []
+                        }
+                    }, territoire)
                 }), TerritoireViewScreen);
 
                 res.send( serializeDocumentToHTML(doc) );

--- a/server/territoireGraphCache-worker.js
+++ b/server/territoireGraphCache-worker.js
@@ -1,0 +1,23 @@
+"use strict";
+
+require('../ES-mess');
+
+console.log('territoireGraphCache-worker', 'represent!')
+
+var territoireGraphCache = require('./territoireGraphCache');
+
+process.on('message', function(msg){
+    //console.log('territoireGraphCache-worker message', msg);
+    
+    var terrId = msg.territoireId;
+    
+    territoireGraphCache(terrId)
+        .then(function(res){
+            process.send(Object.assign({
+                territoireId: terrId
+            }, res));
+        })
+        .catch(function(e){
+            console.error('territoireGraphCache-worker error', e, e.stack);
+        })
+});

--- a/server/territoireGraphCache.js
+++ b/server/territoireGraphCache.js
@@ -20,7 +20,7 @@ var cache = new Map();
 var scheduledRefreshes = new Set/*<territoireId>*/()
 
 function refreshCacheEntry(territoireId){
-    console.log('refreshCacheEntry', territoireId);
+    //console.log('refreshCacheEntry', territoireId);
     
     if(scheduledRefreshes.has(territoireId))
         return; // already scheduled
@@ -29,7 +29,7 @@ function refreshCacheEntry(territoireId){
     
     return database.complexQueries.getTerritoireGraph(territoireId)
         .then(function(graph){
-            console.log('refreshCacheEntry', territoireId, 'done');
+            //console.log('refreshCacheEntry', territoireId, 'done');
             cache.set(territoireId, {
                 graph: graph,
                 buildTime: Date.now()
@@ -42,7 +42,7 @@ function refreshCacheEntry(territoireId){
 module.exports = function(territoireId){
     var entry = cache.get(territoireId);
     
-    console.log('territoireGraphCache', entry);
+    console.log('territoireGraphCache entry', entry);
     
     if(entry){
         entry.lastAccessTime = Date.now();

--- a/server/territoireGraphCache.js
+++ b/server/territoireGraphCache.js
@@ -1,0 +1,103 @@
+"use strict";
+
+var StringMap = require('stringmap');
+
+var database = require('../database');
+
+// var ONE_HOUR = 60*60*1000;
+
+/*
+    territoireId => mutable{
+        graph: aGraph
+        lastAccessTime?: timestamp
+        builtTime: timestamp
+    }
+*/
+var cache = new Map();
+
+
+
+var scheduledRefreshes = new Set/*<territoireId>*/()
+
+function refreshCacheEntry(territoireId){
+    console.log('refreshCacheEntry', territoireId);
+    
+    if(scheduledRefreshes.has(territoireId))
+        return; // already scheduled
+    
+    scheduledRefreshes.add(territoireId);
+    
+    return database.complexQueries.getTerritoireGraph(territoireId)
+        .then(function(graph){
+            console.log('refreshCacheEntry', territoireId, 'done');
+            cache.set(territoireId, {
+                graph: graph,
+                buildTime: Date.now()
+            });
+            scheduledRefreshes.delete(territoireId);
+        })
+}
+
+
+module.exports = function(territoireId){
+    var entry = cache.get(territoireId);
+    
+    console.log('territoireGraphCache', entry);
+    
+    if(entry){
+        entry.lastAccessTime = Date.now();
+        
+        // schedule a refresh of the entry
+        refreshCacheEntry(territoireId)
+        
+        return Promise.resolve({
+            graph: entry.graph,
+            complete: true 
+        });
+    }
+    else{
+        // schedule getting the full graph
+        refreshCacheEntry(territoireId)
+
+        // Get the territoire query results and make a graph out of that to be returned ASAP
+        return database.complexQueries.getTerritoireQueryResults(territoireId)
+            .then(database.Resources.findValidByURLs)
+            .then(function(resources){            
+                var nodes = new StringMap();
+            
+                resources.forEach(function(res){
+                    if(res.alias_of !== null)
+                        return;
+
+                    var idKey = String(res.id);
+
+                    nodes.set(idKey, Object.assign({
+                        depth: 0
+                    }, res));
+                });
+            
+                return {
+                    nodes: nodes,
+                    edges: new Set(),
+                    toJSON: function(){
+                        return {
+                            nodes: nodes.values(),
+                            edges: []
+                        }
+                    }
+                };
+            })
+            .then(function(graph){
+                return {
+                    graph: graph,
+                    complete: false 
+                };
+            })
+    }
+    
+    
+    
+    
+    
+    
+}


### PR DESCRIPTION
In this PR, `/territoire/:id` perf is improved in 2 ways:
* a process caches resourceId graphs per territoireId and is able to return the graph super-quickly when asked. If graph isn't in cache, a no-edge graph with the query results is returned.
* server-side `/territoire/:id` rendering is disabled.