### PR TITLE
Convert max_results to a number from the form before sending to server

### DIFF
--- a/client/components/QueryForm.js
+++ b/client/components/QueryForm.js
@@ -85,6 +85,9 @@ module.exports = React.createClass({
                                     value.to = to;
                                 
                                 break;
+                            case 'number':
+                                value = Number(el.value);
+                                break;
                             default:
                                 // works for Array.isArray(type) (select/option)
                                 value = el.value;       


### PR DESCRIPTION
This PR fixes a bug that doesn't have a corresponding issue.
The max number of results was sent as a string which the [GCSE oracle was ignoring and replacing by 100](https://github.com/MyWebIntelligence/MyWebIntelligence/blob/8217bab4f0bf80f0d4e3393c45b263b503c14945/oracles/GCSE.js#L133-L134).

Number for numbers are good.